### PR TITLE
Add attribution for @akheron

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -84,7 +84,8 @@ the [contributing guide](Contributing.md).
 ## People
 
 HTTPure is written and maintained
-by [Connor Prussin](https://connor.prussin.net).
+by [Connor Prussin](https://connor.prussin.net) and [Petri
+Lehtinen](http://www.digip.org/).
 
 We are open to accepting contributions! Please see
 the [contributing guide](./Contributing.md).


### PR DESCRIPTION
Is this how you'd prefer to be attributed or would you prefer some other link (email, github profile, etc)?