### PR TITLE
Update the tests to work with purescript-spec v4.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "purescript-exceptions": "^4.0.0",
     "purescript-foldable-traversable": "^4.0.0",
     "purescript-foreign": "^5.0.0",
+    "purescript-globals": "^4.1.0",
     "purescript-lists": "^5.4.0",
     "purescript-maybe": "^4.0.1",
     "purescript-newtype": "^3.0.0",
@@ -38,15 +39,13 @@
     "purescript-node-streams": "^4.0.0",
     "purescript-nullable": "^4.1.1",
     "purescript-options": "^5.0.0",
-    "purescript-ordered-collections": "^1.6.1",
     "purescript-prelude": "^4.0.1",
     "purescript-psci-support": "^4.0.0",
     "purescript-refs": "^4.1.0",
-    "purescript-spec": "^3.0.0",
+    "purescript-spec": "^4.0.0",
     "purescript-strings": "^4.0.0",
     "purescript-tuples": "^5.1.0",
     "purescript-type-equality": "^3.0.0",
-    "purescript-unsafe-coerce": "^4.0.0",
-    "purescript-globals": "^4.1.0"
+    "purescript-unsafe-coerce": "^4.0.0"
   }
 }

--- a/test/Test/HTTPure/ServerSpec.purs
+++ b/test/Test/HTTPure/ServerSpec.purs
@@ -13,7 +13,7 @@ import Node.Encoding as Encoding
 import Node.HTTP.Secure as HTTPS
 import Node.FS.Sync as FSSync
 import Test.Spec as Spec
-import Test.Spec.Assertions.Aff as AffAssertions
+import Test.Spec.Assertions as Assertions
 
 import HTTPure.Request as Request
 import HTTPure.Response as Response
@@ -64,7 +64,7 @@ serveSecureSpec = Spec.describe "serveSecure" do
       out ?= "/test"
   Spec.describe "with invalid key and cert files" do
     Spec.it "throws" do
-      AffAssertions.expectError $ EffectClass.liftEffect $
+      Assertions.expectError $ EffectClass.liftEffect $
         Server.serveSecure 8080 "" "" mockRouter $ pure unit
   where
     cert = "./test/Mocks/Certificate.cer"

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -2,6 +2,7 @@ module Test.Main where
 
 import Prelude
 
+import Effect.Aff as Aff
 import Test.Spec as Spec
 import Test.Spec.Reporter as Reporter
 import Test.Spec.Runner as Runner
@@ -22,7 +23,7 @@ import Test.HTTPure.IntegrationSpec as IntegrationSpec
 import Test.HTTPure.TestHelpers as TestHelpers
 
 main :: TestHelpers.TestSuite
-main = Runner.run [ Reporter.specReporter ] $ Spec.describe "HTTPure" do
+main = Aff.launchAff_ $ Runner.runSpec [ Reporter.specReporter ] $ Spec.describe "HTTPure" do
   BodySpec.bodySpec
   HeadersSpec.headersSpec
   LookupSpec.lookupSpec


### PR DESCRIPTION
This version was already being pulled in by the package set, so the test compilation was breaking.

Also update bower.json to match the package set dependencies.

Fix #143 