### PR TITLE
Add some type declarations to get compatibility with node-buffer 6.x.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "purescript-lists": "^5.4.0",
     "purescript-maybe": "^4.0.1",
     "purescript-newtype": "^3.0.0",
-    "purescript-node-buffer": "^5.0.0",
+    "purescript-node-buffer": "^5.0.0 || ^6.0.0",
     "purescript-node-child-process": "^6.0.0",
     "purescript-node-fs": "^5.0.0",
     "purescript-node-fs-aff": "^6.0.0",

--- a/src/HTTPure/Body.purs
+++ b/src/HTTPure/Body.purs
@@ -39,7 +39,9 @@ class Body b where
 -- | response stream and closing the response stream.
 instance bodyString :: Body String where
 
-  defaultHeaders body = Buffer.fromString body Encoding.UTF8 >>= defaultHeaders
+  defaultHeaders body = do
+    buf :: Buffer.Buffer <- Buffer.fromString body Encoding.UTF8
+    defaultHeaders buf
 
   write body response = Aff.makeAff \done -> do
     let stream = HTTP.responseAsStream response

--- a/test/Test/HTTPure/BodySpec.purs
+++ b/test/Test/HTTPure/BodySpec.purs
@@ -33,7 +33,7 @@ defaultHeadersSpec = Spec.describe "defaultHeaders" do
         headers ?= Headers.header "Content-Length" "3"
   Spec.describe "Buffer" do
     Spec.it "has the correct Content-Length header" do
-      buf <- EffectClass.liftEffect $ Buffer.fromString "foobar" Encoding.UTF8
+      buf :: Buffer.Buffer <- EffectClass.liftEffect $ Buffer.fromString "foobar" Encoding.UTF8
       headers <- EffectClass.liftEffect $ Body.defaultHeaders buf
       headers ?= Headers.header "Content-Length" "6"
   Spec.describe "Readable" do
@@ -55,7 +55,7 @@ writeSpec = Spec.describe "write" do
     Spec.it "writes the Buffer to the Response body" do
       body <- do
         resp <- EffectClass.liftEffect TestHelpers.mockResponse
-        buf <- EffectClass.liftEffect $ Buffer.fromString "test" Encoding.UTF8
+        buf :: Buffer.Buffer <- EffectClass.liftEffect $ Buffer.fromString "test" Encoding.UTF8
         Body.write buf resp
         pure $ TestHelpers.getResponseBody resp
       body ?= "test"


### PR DESCRIPTION
Since node-buffer 6.x is not yet in the package set, compatibility with node-buffer 5.x is maintained in `bower.json`.