### PR TITLE
Update to purescript 0.14

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200127/packages.dhall sha256:06a623f48c49ea1c7675fdf47f81ddb02ae274558e29f511efae1df99ea92fb8
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210302/packages.dhall sha256:20cc5b89cf15433623ad6f250f112bf7a6bd82b5972363ecff4abf1febb02c50
 
 let overrides = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -10,7 +10,6 @@
     , "exceptions"
     , "foldable-traversable"
     , "foreign"
-    , "globals"
     , "lists"
     , "maybe"
     , "newtype"
@@ -30,6 +29,7 @@
     , "tuples"
     , "type-equality"
     , "unsafe-coerce"
+    , "js-uri"
     ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs", "docs/**/*.purs" ]

--- a/src/HTTPure/Utils.purs
+++ b/src/HTTPure/Utils.purs
@@ -1,6 +1,5 @@
 module HTTPure.Utils
-  ( module Global
-  , encodeURIComponent
+  ( encodeURIComponent
   , replacePlus
   , urlDecode
   ) where
@@ -9,12 +8,10 @@ import Prelude
 
 import Data.Maybe as Maybe
 import Data.String as String
-import Global (decodeURIComponent) as Global
-import Global.Unsafe (unsafeEncodeURIComponent)
-
+import JSURI as JSURI
 
 encodeURIComponent :: String -> String
-encodeURIComponent = unsafeEncodeURIComponent
+encodeURIComponent s = Maybe.fromMaybe s $ JSURI.encodeURIComponent s
 
 
 replacePlus :: String -> String
@@ -24,4 +21,4 @@ replacePlus =
 
 urlDecode :: String -> String
 urlDecode s =
-  Maybe.fromMaybe s $ Global.decodeURIComponent s
+  Maybe.fromMaybe s $ JSURI.decodeURIComponent s


### PR DESCRIPTION
Contains breaking changes I guess because the Global module doesn't exist anymore and cannot be exported with the Utils module anymore. Besides that this fixes compile errors under purescript 0.14