### PR TITLE
Don't use `echo -n` since it's nonportable to OSX

### DIFF
--- a/docs/Examples/Chunked/Main.purs
+++ b/docs/Examples/Chunked/Main.purs
@@ -17,7 +17,7 @@ runScript script = EffectClass.liftEffect $ ChildProcess.stdout <$>
 -- | Say 'hello world!' in chunks when run
 sayHello :: HTTPure.Request -> HTTPure.ResponseM
 sayHello =
-  const $ runScript "echo -n 'hello '; sleep 1; echo -n 'world!'" >>= HTTPure.ok
+  const $ runScript "echo 'hello '; sleep 1; echo 'world!'" >>= HTTPure.ok
 
 -- | Boot up the server
 main :: HTTPure.ServerM

--- a/test/Test/HTTPure/IntegrationSpec.purs
+++ b/test/Test/HTTPure/IntegrationSpec.purs
@@ -48,7 +48,7 @@ chunkedSpec = Spec.it "runs the chunked example" do
   EffectClass.liftEffect $ close $ pure unit
   -- TODO this isn't a great way to validate this, we need a way of inspecting
   -- each individual chunk instead of just looking at the entire response
-  response ?= "hello world!"
+  response ?= "hello \nworld!\n"
 
 customStackSpec :: TestHelpers.Test
 customStackSpec = Spec.it "runs the custom stack example" do


### PR DESCRIPTION
It seems `echo` on OSX does not handle flags, so this PR changes the chunked example to use a flagless echo so that the test works on mac too.