### PR TITLE
Migrate from `purty` to `purs-tidy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /output
 /.psa-stash
 /.psci_modules
+/.psc-ide-port

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,9 @@
+{
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -3,7 +3,7 @@
   "indent": 2,
   "operatorsFile": null,
   "ribbon": 1,
-  "typeArrowPlacement": "first",
+  "typeArrowPlacement": "last",
   "unicode": "never",
   "width": null
 }

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PULP := pulp
 NODE := node
 YARN := yarn
 BOWER := bower
-PURTY := purty
+PURSTIDY := purs-tidy
 
 # Options to pass to pulp when building
 BUILD_OPTIONS := -- --stash --censor-lib --strict
@@ -89,14 +89,10 @@ example: $(BUILD) $(EXAMPLE_INDEX)
 endif
 
 format: $(MODULES) $(SOURCES) $(TESTSOURCES) $(EXAMPLESOURCES)
-	$(PURTY) format --write $(SRCPATH)
-	$(PURTY) format --write $(TESTPATH)
-	$(PURTY) format --write $(EXAMPLESPATH)
+	$(PURSTIDY) format-in-place $(SRCPATH) $(TESTPATH) $(EXAMPLESPATH)
 
 test-format: $(MODULES) $(SOURCES) $(TESTSOURCES) $(EXAMPLESOURCES)
-	$(PURTY) validate $(SRCPATH) &&\
-	  $(PURTY) validate $(TESTPATH) &&\
-	  $(PURTY) validate $(EXAMPLESPATH)
+	$(PURSTIDY) check $(SRCPATH) $(TESTPATH) $(EXAMPLESPATH)
 
 # Run the test suite
 test-code: $(BUILD) $(TESTSOURCES) $(EXAMPLESOURCES) $(MODULES)

--- a/docs/Examples/CustomStack/Main.purs
+++ b/docs/Examples/CustomStack/Main.purs
@@ -8,9 +8,7 @@ import Effect.Console as Console
 import HTTPure as HTTPure
 
 -- | A type to hold the environment for our ReaderT
-type Env
-  = { name :: String
-    }
+type Env = { name :: String }
 
 -- | A middleware that introduces a ReaderT
 readerMiddleware ::

--- a/docs/Examples/Middleware/Main.purs
+++ b/docs/Examples/Middleware/Main.purs
@@ -37,7 +37,6 @@ pathMiddleware ::
   HTTPure.Request ->
   HTTPure.ResponseM
 pathMiddleware _ { path: [ "middleware" ] } = HTTPure.ok "Middleware!"
-
 pathMiddleware router request = router request
 
 -- | Say 'hello' when run, and add a default value to the X-Middleware header

--- a/docs/Examples/MultiRoute/Main.purs
+++ b/docs/Examples/MultiRoute/Main.purs
@@ -7,9 +7,7 @@ import HTTPure as HTTPure
 -- | Specify the routes
 router :: HTTPure.Request -> HTTPure.ResponseM
 router { path: [ "hello" ] } = HTTPure.ok "hello"
-
 router { path: [ "goodbye" ] } = HTTPure.ok "goodbye"
-
 router _ = HTTPure.notFound
 
 -- | Boot up the server

--- a/docs/Examples/Post/Main.purs
+++ b/docs/Examples/Post/Main.purs
@@ -7,7 +7,6 @@ import HTTPure as HTTPure
 -- | Route to the correct handler
 router :: HTTPure.Request -> HTTPure.ResponseM
 router { body, method: HTTPure.Post } = HTTPure.ok body
-
 router _ = HTTPure.notFound
 
 -- | Boot up the server

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
         "bower": "^1.8.12",
         "pulp": "^15.0.0",
         "purescript-psa": "^0.8.2",
-        "purty": "^7.0.0"
+        "purs-tidy": "^0.6.2"
     }
 }

--- a/src/HTTPure/Request.purs
+++ b/src/HTTPure/Request.purs
@@ -19,15 +19,15 @@ import HTTPure.Version as Version
 
 -- | The `Request` type is a `Record` type that includes fields for accessing
 -- | the different parts of the HTTP request.
-type Request
-  = { method :: Method.Method
-    , path :: Path.Path
-    , query :: Query.Query
-    , headers :: Headers.Headers
-    , body :: String
-    , httpVersion :: Version.Version
-    , url :: String
-    }
+type Request =
+  { method :: Method.Method
+  , path :: Path.Path
+  , query :: Query.Query
+  , headers :: Headers.Headers
+  , body :: String
+  , httpVersion :: Version.Version
+  , url :: String
+  }
 
 -- | Return the full resolved path, including query parameters. This may not
 -- | match the requested path--for instance, if there are empty path segments in
@@ -50,12 +50,12 @@ fullPath request = "/" <> path <> questionMark <> queryParams
 fromHTTPRequest :: HTTP.Request -> Aff.Aff Request
 fromHTTPRequest request = do
   body <- Body.read request
-  pure
-    $ { method: Method.read request
-      , path: Path.read request
-      , query: Query.read request
-      , headers: Headers.read request
-      , body
-      , httpVersion: Version.read request
-      , url: HTTP.requestURL request
-      }
+  pure $
+    { method: Method.read request
+    , path: Path.read request
+    , query: Query.read request
+    , headers: Headers.read request
+    , body
+    , httpVersion: Version.read request
+    , url: HTTP.requestURL request
+    }

--- a/src/HTTPure/Response.purs
+++ b/src/HTTPure/Response.purs
@@ -146,15 +146,14 @@ import HTTPure.Status as Status
 -- | The `ResponseM` type simply conveniently wraps up an HTTPure monad that
 -- | returns a response. This type is the return type of all router/route
 -- | methods.
-type ResponseM
-  = Aff.Aff Response
+type ResponseM = Aff.Aff Response
 
 -- | A `Response` is a status code, headers, and a body.
-type Response
-  = { status :: Status.Status
-    , headers :: Headers.Headers
-    , writeBody :: HTTP.Response -> Aff.Aff Unit
-    }
+type Response =
+  { status :: Status.Status
+  , headers :: Headers.Headers
+  , writeBody :: HTTP.Response -> Aff.Aff Unit
+  }
 
 -- | Given an HTTP `Response` and a HTTPure `Response`, this method will return
 -- | a monad encapsulating writing the HTTPure `Response` to the HTTP `Response`

--- a/src/HTTPure/Server.purs
+++ b/src/HTTPure/Server.purs
@@ -47,8 +47,7 @@ handleRequest ::
   HTTP.Response ->
   Effect.Effect Unit
 handleRequest router request httpresponse =
-  void $ Aff.runAff (\_ -> pure unit)
-    $ Request.fromHTTPRequest request
+  void $ Aff.runAff (\_ -> pure unit) $ Request.fromHTTPRequest request
     >>= onError500 router
     >>= Response.send httpresponse
 
@@ -121,5 +120,4 @@ serveSecure port cert key router onStarted = do
   where
   sslOpts key' cert' =
     HTTPS.key := HTTPS.keyString key'
-      <> HTTPS.cert
-      := HTTPS.certString cert'
+      <> HTTPS.cert := HTTPS.certString cert'

--- a/test/Test/HTTPure/HeadersSpec.purs
+++ b/test/Test/HTTPure/HeadersSpec.purs
@@ -99,11 +99,10 @@ writeSpec :: TestHelpers.Test
 writeSpec =
   Spec.describe "write" do
     Spec.it "writes the headers to the response" do
-      header <-
-        EffectClass.liftEffect do
-          mock <- TestHelpers.mockResponse
-          Headers.write mock $ Headers.header "X-Test" "test"
-          pure $ TestHelpers.getResponseHeader "X-Test" mock
+      header <- EffectClass.liftEffect do
+        mock <- TestHelpers.mockResponse
+        Headers.write mock $ Headers.header "X-Test" "test"
+        pure $ TestHelpers.getResponseHeader "X-Test" mock
       header ?= "test"
 
 emptySpec :: TestHelpers.Test

--- a/test/Test/HTTPure/ServerSpec.purs
+++ b/test/Test/HTTPure/ServerSpec.purs
@@ -94,11 +94,9 @@ serveSecure'Spec =
   sslOptions = do
     cert <- FSSync.readTextFile Encoding.UTF8 "./test/Mocks/Certificate.cer"
     key <- FSSync.readTextFile Encoding.UTF8 "./test/Mocks/Key.key"
-    pure
-      $ HTTPS.key
-      := HTTPS.keyString key
-      <> HTTPS.cert
-      := HTTPS.certString cert
+    pure $
+      HTTPS.key := HTTPS.keyString key
+        <> HTTPS.cert := HTTPS.certString cert
 
 serverSpec :: TestHelpers.Test
 serverSpec =

--- a/test/Test/HTTPure/TestHelpers.purs
+++ b/test/Test/HTTPure/TestHelpers.purs
@@ -55,18 +55,12 @@ request secure port method headers path body =
   where
   options =
     HTTPClient.protocol := (if secure then "https:" else "http:")
-      <> HTTPClient.method
-      := method
-      <> HTTPClient.hostname
-      := "localhost"
-      <> HTTPClient.port
-      := port
-      <> HTTPClient.path
-      := path
-      <> HTTPClient.headers
-      := HTTPClient.RequestHeaders headers
-      <> HTTPClient.rejectUnauthorized
-      := false
+      <> HTTPClient.method := method
+      <> HTTPClient.hostname := "localhost"
+      <> HTTPClient.port := port
+      <> HTTPClient.path := path
+      <> HTTPClient.headers := HTTPClient.RequestHeaders headers
+      <> HTTPClient.rejectUnauthorized := false
 
 -- | Convert a request to an Aff containing the `Buffer with the response body.
 toBuffer :: HTTPClient.Response -> Aff.Aff Buffer.Buffer
@@ -76,13 +70,12 @@ toBuffer response =
       stream = HTTPClient.responseAsStream response
     chunks <- Ref.new List.Nil
     Stream.onData stream $ \new -> Ref.modify_ (List.Cons new) chunks
-    Stream.onEnd stream
-      $ Ref.read chunks
+    Stream.onEnd stream $ Ref.read chunks
       >>= List.reverse
-      >>> Array.fromFoldable
-      >>> Buffer.concat
+        >>> Array.fromFoldable
+        >>> Buffer.concat
       >>= Either.Right
-      >>> done
+        >>> done
     pure Aff.nonCanceler
 
 -- | Convert a request to an Aff containing the string with the response body.

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -21,19 +21,17 @@ import Test.HTTPure.IntegrationSpec as IntegrationSpec
 import Test.HTTPure.TestHelpers as TestHelpers
 
 main :: TestHelpers.TestSuite
-main =
-  Aff.launchAff_ $ Runner.runSpec [ Reporter.specReporter ]
-    $ Spec.describe "HTTPure" do
-        BodySpec.bodySpec
-        HeadersSpec.headersSpec
-        LookupSpec.lookupSpec
-        MethodSpec.methodSpec
-        PathSpec.pathSpec
-        QuerySpec.querySpec
-        RequestSpec.requestSpec
-        ResponseSpec.responseSpec
-        ServerSpec.serverSpec
-        StatusSpec.statusSpec
-        UtilsSpec.utilsSpec
-        VersionSpec.versionSpec
-        IntegrationSpec.integrationSpec
+main = Aff.launchAff_ $ Runner.runSpec [ Reporter.specReporter ] $ Spec.describe "HTTPure" do
+  BodySpec.bodySpec
+  HeadersSpec.headersSpec
+  LookupSpec.lookupSpec
+  MethodSpec.methodSpec
+  PathSpec.pathSpec
+  QuerySpec.querySpec
+  RequestSpec.requestSpec
+  ResponseSpec.responseSpec
+  ServerSpec.serverSpec
+  StatusSpec.statusSpec
+  UtilsSpec.utilsSpec
+  VersionSpec.versionSpec
+  IntegrationSpec.integrationSpec

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,10 +945,10 @@ purescript-psa@^0.8.2:
   resolved "https://registry.yarnpkg.com/purescript-psa/-/purescript-psa-0.8.2.tgz#ee20c40f02cd0c5ed6dd3dd93ef02d9c466f17bc"
   integrity sha512-4Olf0aQQrNCfcDLXQI3gJgINEQ+3U+4QPLmQ2LHX2L/YOXSwM7fOGIUs/wMm/FQnwERUyQmHKQTJKB4LIjE2fg==
 
-purty@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/purty/-/purty-7.0.0.tgz#3a714a2155f543118c6831e1fb41b84d17de2b59"
-  integrity sha512-gHHghPEjRY39GUJ8KnOMRfPArJILGCXwEhX6BmEdNiLgZuCjLLBLyawGiKFjYMfy8H5Dsk5NbgwIGslrPrernA==
+purs-tidy@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/purs-tidy/-/purs-tidy-0.6.2.tgz#3f17b5a1fe47183a2c41b2640b1fe2aff9ca5a1d"
+  integrity sha512-vakkmCDlb9G8A7m6azxjbUfuwz6Lomn93RRWcqNrQbNIHDwBs05pfLZb5XslqcNbP5UIJ4wfL+YhL1/GlfNoBw==
 
 querystring-es3@~0.2.0:
   version "0.2.1"


### PR DESCRIPTION
👋 Hi @cprussin! This is a small pull request that migrates from `purty` to [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) for formatting. I was working on the library a little and found that `purty` causes a few odd formatting decisions that aren't usually present in PureScript code, and we've seen a great result using `purs-tidy` at work at Awake, Halogen, the PureScript registry, and more.

In this PR I've kept the formatting changes minimal and preserved the arrow-last style used by `purty`. However, `purs-tidy` supports both arrow-first and arrow-last formatting, and so if you'd like to switch then I can push a commit changing that so you can see how it feels.

The biggest changes are in operators and in equational-style function declarations; I'll add comments to those directly to call them out in the review.

Of course, if you are not interested in switching then feel free to close this PR. Thanks!